### PR TITLE
remove typescript override

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,5 @@
   "devDependencies": {
     "prettier": "^3.8.3",
     "prettier-plugin-astro": "^0.14.1"
-  },
-  "overrides": {
-    "@astrojs/check": {
-      "typescript": "$typescript"
-    }
   }
 }


### PR DESCRIPTION
It seems this was fixed in 6.1.10 the override should no longer prevent builds.